### PR TITLE
Optionally pass request to service interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ The plugin is executed as part of a protoc compilation step:
 
 The flit plugin accepts the following plugin parameters:
 
-| Name          | Required  | Type                              | Description                                               |
-|:--------------|:---------:|:----------------------------------|:----------------------------------------------------------|
-| `target`      | Y         | `enum[server]`                    | The type of target to generate e.g. server, client etc    |
-| `type`        | Y         | `enum[spring,undertow,boot,jaxrs]`| Type of target to generate                                |
-| `context`     | N         | `string`                          | Base context for routing, default is `/twirp`             |
+| Name      | Required  | Type                              | Description                                            |
+|:----------|:---------:|:----------------------------------|:-------------------------------------------------------|
+| `target`  | Y         | `enum[server]`                    | The type of target to generate e.g. server, client etc |
+| `type`    | Y         | `enum[spring,undertow,boot,jaxrs]`| Type of target to generate                             |
+| `context` | N         | `string`                          | Base context for routing, default is `/twirp`          |
+| `request` | N         | `string`                          | If the request parameter should pass to the service    |
 
 # Development
 

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,1 +1,1 @@
-version=1.2.0
+version=1.2.1

--- a/plugin/src/main/java/com/flit/protoc/Parameter.java
+++ b/plugin/src/main/java/com/flit/protoc/Parameter.java
@@ -1,13 +1,12 @@
 package com.flit.protoc;
 
 import com.flit.protoc.gen.GeneratorException;
-import lombok.Getter;
-import lombok.ToString;
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.ToString;
 
 @Getter @ToString public class Parameter {
 
@@ -15,9 +14,10 @@ import java.util.stream.Collectors;
   public static final String PARAM_CLIENT = "client";
   public static final String PARAM_TYPE = "type";
   public static final String PARAM_CONTEXT = "context";
+  public static final String PARAM_REQUEST = "request";
 
-  private String key;
-  private String value;
+  private final String key;
+  private final String value;
 
   public Parameter(String[] strings) {
     this.key = strings[0];

--- a/plugin/src/main/java/com/flit/protoc/gen/server/BaseServerGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/BaseServerGenerator.java
@@ -1,17 +1,17 @@
 package com.flit.protoc.gen.server;
 
+import static com.flit.protoc.Parameter.PARAM_CONTEXT;
+
 import com.flit.protoc.Parameter;
 import com.flit.protoc.gen.Generator;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto;
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
-
+import com.squareup.javapoet.TypeName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import static com.flit.protoc.Parameter.PARAM_CONTEXT;
 
 /**
  * Implements the basic "generate a service interface + impl dispatcher".
@@ -21,13 +21,19 @@ import static com.flit.protoc.Parameter.PARAM_CONTEXT;
  */
 public abstract class BaseServerGenerator implements Generator {
 
+  private final List<String> requestServices;
+
+  protected BaseServerGenerator(List<String> requestServices) {
+    this.requestServices = requestServices;
+  }
+
   @Override public List<CodeGeneratorResponse.File> generate(CodeGeneratorRequest request, Map<String, Parameter> params) {
     List<CodeGeneratorResponse.File> files = new ArrayList<>();
     String context = getContext(params);
     TypeMapper mapper = new TypeMapper(request.getProtoFileList());
     request.getProtoFileList().forEach(proto -> {
       proto.getServiceList().forEach(s -> {
-        files.addAll(new ServiceGenerator(proto, s, mapper).getFiles());
+        files.addAll(new ServiceGenerator(proto, s, mapper, isRequestBasedClass(s), getHttpRequestTypeName()).getFiles());
         files.addAll(getRpcGenerator(proto, s, context, mapper).getFiles());
       });
     });
@@ -41,5 +47,11 @@ public abstract class BaseServerGenerator implements Generator {
     return null;
   }
 
+  protected boolean isRequestBasedClass(ServiceDescriptorProto service) {
+    return requestServices.contains(service.getName());
+  }
+
   protected abstract BaseGenerator getRpcGenerator(FileDescriptorProto proto, ServiceDescriptorProto service, String context, TypeMapper mapper);
+
+  protected abstract TypeName getHttpRequestTypeName();
 }

--- a/plugin/src/main/java/com/flit/protoc/gen/server/ServiceGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/ServiceGenerator.java
@@ -4,34 +4,48 @@ import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.compiler.PluginProtos;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-
-import javax.lang.model.element.Modifier;
 import java.util.Collections;
 import java.util.List;
+import javax.lang.model.element.Modifier;
 
 /**
  * Generates the `Rpc${SerivceName}` interface.
  *
- * Currently this is the same interface across both undertow and spring.
+ * Currently, this is the same interface across both undertow and spring.
  */
 public class ServiceGenerator extends BaseGenerator {
 
   private final TypeSpec.Builder rpcInterface;
+  private final boolean passRequest;
+  private final TypeName httpRequestType;
 
-  public ServiceGenerator(DescriptorProtos.FileDescriptorProto proto, DescriptorProtos.ServiceDescriptorProto s, TypeMapper mapper) {
+  public ServiceGenerator(
+      DescriptorProtos.FileDescriptorProto proto,
+      DescriptorProtos.ServiceDescriptorProto s,
+      TypeMapper mapper,
+      boolean passRequest,
+      TypeName httpRequestType
+  ) {
     super(proto, s, mapper);
+    this.passRequest = passRequest;
+    this.httpRequestType = httpRequestType;
     rpcInterface = TypeSpec.interfaceBuilder(ClassName.get(javaPackage, "Rpc" + service.getName()));
     rpcInterface.addModifiers(Modifier.PUBLIC);
     service.getMethodList().forEach(this::addHandleMethod);
   }
 
   private void addHandleMethod(DescriptorProtos.MethodDescriptorProto m) {
-    rpcInterface.addMethod(MethodSpec.methodBuilder("handle" + m.getName())
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("handle" + m.getName());
+    if (passRequest) {
+      builder.addParameter(httpRequestType, "request");
+    }
+    builder
       .addParameter(mapper.get(m.getInputType()), "in")
       .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
-      .returns(mapper.get(m.getOutputType()))
-      .build());
+      .returns(mapper.get(m.getOutputType()));
+    rpcInterface.addMethod(builder.build());
   }
 
   @Override public List<PluginProtos.CodeGeneratorResponse.File> getFiles() {

--- a/plugin/src/main/java/com/flit/protoc/gen/server/jaxrs/JaxrsGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/jaxrs/JaxrsGenerator.java
@@ -1,16 +1,29 @@
 package com.flit.protoc.gen.server.jaxrs;
 
+import static com.flit.protoc.gen.server.jaxrs.RpcGenerator.HttpServletRequest;
+
 import com.flit.protoc.gen.server.BaseGenerator;
 import com.flit.protoc.gen.server.BaseServerGenerator;
 import com.flit.protoc.gen.server.TypeMapper;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto;
+import com.squareup.javapoet.TypeName;
+import java.util.List;
 
 public class JaxrsGenerator extends BaseServerGenerator {
+
+  public JaxrsGenerator(List<String> requestServices) {
+    super(requestServices);
+  }
 
   @Override
   protected BaseGenerator getRpcGenerator(FileDescriptorProto proto, ServiceDescriptorProto service,
       String context, TypeMapper mapper) {
-    return new RpcGenerator(proto, service, context, mapper);
+    return new RpcGenerator(proto, service, context, mapper, isRequestBasedClass(service));
+  }
+
+  @Override
+  protected TypeName getHttpRequestTypeName() {
+    return HttpServletRequest;
   }
 }

--- a/plugin/src/main/java/com/flit/protoc/gen/server/spring/SpringGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/spring/SpringGenerator.java
@@ -1,19 +1,32 @@
 package com.flit.protoc.gen.server.spring;
 
+import static com.flit.protoc.gen.server.spring.RpcGenerator.HttpServletRequest;
+
 import com.flit.protoc.gen.server.BaseGenerator;
 import com.flit.protoc.gen.server.BaseServerGenerator;
 import com.flit.protoc.gen.server.TypeMapper;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto;
+import com.squareup.javapoet.TypeName;
+import java.util.List;
 
 /**
  * Spring specific generator that will output MVC style routes.
  */
 public class SpringGenerator extends BaseServerGenerator {
 
-  @Override protected BaseGenerator getRpcGenerator(
-    FileDescriptorProto proto, ServiceDescriptorProto service, String context, TypeMapper mapper) {
-    return new RpcGenerator(proto, service, context, mapper);
+  public SpringGenerator(List<String> requestServices) {
+    super(requestServices);
   }
 
+  @Override
+  protected BaseGenerator getRpcGenerator(
+    FileDescriptorProto proto, ServiceDescriptorProto service, String context, TypeMapper mapper) {
+    return new RpcGenerator(proto, service, context, mapper, isRequestBasedClass(service));
+  }
+
+  @Override
+  protected TypeName getHttpRequestTypeName() {
+    return HttpServletRequest;
+  }
 }

--- a/plugin/src/main/java/com/flit/protoc/gen/server/undertow/RpcGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/undertow/RpcGenerator.java
@@ -159,9 +159,9 @@ class RpcGenerator extends BaseGenerator {
 
   private String getRouteToService() {
     if (passRequest) {
-      return "$T retval = service.handle$L(exchange, data)";
+      return "$T response = service.handle$L(exchange, data)";
     } else {
-      return "$T retval = service.handle$L(data)";
+      return "$T response = service.handle$L(data)";
     }
   }
 

--- a/plugin/src/main/java/com/flit/protoc/gen/server/undertow/RpcGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/undertow/RpcGenerator.java
@@ -1,31 +1,52 @@
 package com.flit.protoc.gen.server.undertow;
 
+import static com.flit.protoc.gen.server.Types.ErrorCode;
+import static com.flit.protoc.gen.server.Types.ErrorWriter;
+import static com.flit.protoc.gen.server.Types.Exception;
+import static com.flit.protoc.gen.server.Types.FlitException;
+import static com.flit.protoc.gen.server.Types.FlitHandler;
+import static com.flit.protoc.gen.server.Types.Headers;
+import static com.flit.protoc.gen.server.Types.HttpServerExchange;
+import static com.flit.protoc.gen.server.Types.InputStreamReader;
+import static com.flit.protoc.gen.server.Types.JsonFormat;
+import static com.flit.protoc.gen.server.Types.Logger;
+import static com.flit.protoc.gen.server.Types.LoggerFactory;
+import static com.flit.protoc.gen.server.Types.Override;
+import static com.flit.protoc.gen.server.Types.StandardCharsets;
+import static javax.lang.model.element.Modifier.FINAL;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.lang.model.element.Modifier.STATIC;
+
 import com.flit.protoc.gen.server.BaseGenerator;
 import com.flit.protoc.gen.server.TypeMapper;
 import com.flit.protoc.gen.server.Types;
 import com.google.common.net.MediaType;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.compiler.PluginProtos;
-import com.squareup.javapoet.*;
-
-import java.lang.Override;
-import java.lang.String;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
 import java.util.Collections;
 import java.util.List;
-
-import static com.flit.protoc.gen.server.Types.*;
-import static com.flit.protoc.gen.server.Types.Exception;
-import static com.flit.protoc.gen.server.Types.Override;
-import static javax.lang.model.element.Modifier.*;
 
 class RpcGenerator extends BaseGenerator {
 
   private final String context;
   private final TypeSpec.Builder rpcHandler;
+  private final boolean passRequest;
 
-  RpcGenerator(DescriptorProtos.FileDescriptorProto proto, DescriptorProtos.ServiceDescriptorProto service, String context, TypeMapper mapper) {
+  RpcGenerator(
+      DescriptorProtos.FileDescriptorProto proto,
+      DescriptorProtos.ServiceDescriptorProto service,
+      String context, TypeMapper mapper,
+      boolean passRequest
+  ) {
     super(proto, service, mapper);
     this.context = getContext(context);
+    this.passRequest = passRequest;
     rpcHandler = TypeSpec.classBuilder(getHandlerName(service))
       .addModifiers(PUBLIC)
       .addSuperinterface(ClassName.bestGuess("io.undertow.server.HttpHandler"));
@@ -123,7 +144,7 @@ class RpcGenerator extends BaseGenerator {
       .addStatement("return")
       .endControlFlow()
       // data is populated, now route to the service
-      .addStatement("$T response = service.handle$L(data)", outputType, m.getName())
+      .addStatement(getRouteToService(), outputType, m.getName())
       .addStatement("exchange.setStatusCode(200)")
       // put the result on the wire
       .beginControlFlow("if (json)")
@@ -134,6 +155,14 @@ class RpcGenerator extends BaseGenerator {
       .addStatement("response.writeTo(exchange.getOutputStream())")
       .endControlFlow()
       .build());
+  }
+
+  private String getRouteToService() {
+    if (passRequest) {
+      return "$T retval = service.handle$L(exchange, data)";
+    } else {
+      return "$T retval = service.handle$L(data)";
+    }
   }
 
   @Override public List<PluginProtos.CodeGeneratorResponse.File> getFiles() {

--- a/plugin/src/main/java/com/flit/protoc/gen/server/undertow/UndertowGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/undertow/UndertowGenerator.java
@@ -1,16 +1,29 @@
 package com.flit.protoc.gen.server.undertow;
 
+import static com.flit.protoc.gen.server.Types.HttpServerExchange;
+
 import com.flit.protoc.gen.server.BaseGenerator;
 import com.flit.protoc.gen.server.BaseServerGenerator;
 import com.flit.protoc.gen.server.TypeMapper;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto;
+import com.squareup.javapoet.TypeName;
+import java.util.List;
 
 public class UndertowGenerator extends BaseServerGenerator {
 
-  @Override protected BaseGenerator getRpcGenerator(
-    FileDescriptorProto proto, ServiceDescriptorProto service, String context, TypeMapper mapper) {
-    return new RpcGenerator(proto, service, context, mapper);
+  public UndertowGenerator(List<String> requestServices) {
+    super(requestServices);
   }
 
+  @Override
+  protected BaseGenerator getRpcGenerator(
+    FileDescriptorProto proto, ServiceDescriptorProto service, String context, TypeMapper mapper) {
+    return new RpcGenerator(proto, service, context, mapper, isRequestBasedClass(service));
+  }
+
+  @Override
+  protected TypeName getHttpRequestTypeName() {
+    return HttpServerExchange;
+  }
 }

--- a/plugin/src/test/java/com/flit/protoc/PluginTest.java
+++ b/plugin/src/test/java/com/flit/protoc/PluginTest.java
@@ -1,11 +1,11 @@
 package com.flit.protoc;
 
-import com.google.protobuf.compiler.PluginProtos;
-import org.junit.Test;
-
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
+import com.google.protobuf.compiler.PluginProtos;
+import org.junit.Test;
 
 public class PluginTest {
 
@@ -14,7 +14,7 @@ public class PluginTest {
     PluginProtos.CodeGeneratorResponse response = plugin.process();
 
     assertTrue("Expected an error for no parameters", response.hasError());
-    assertEquals("Incorrect error message", "Usage: --flit_out=target=server,type=[spring|undertow|jaxrs]:<PATH>", response.getError());
+    assertEquals("Incorrect error message", "Usage: --flit_out=target=server,type=[spring|undertow|jaxrs][,request=[class(es)]]:<PATH>", response.getError());
   }
 
   @Test public void test_NoTargetSpecified() {

--- a/plugin/src/test/java/com/flit/protoc/gen/BaseGeneratorTest.java
+++ b/plugin/src/test/java/com/flit/protoc/gen/BaseGeneratorTest.java
@@ -1,23 +1,29 @@
 package com.flit.protoc.gen;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.github.javaparser.JavaParser;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.compiler.PluginProtos;
 import com.google.protobuf.util.JsonFormat;
-import org.apache.commons.io.FileUtils;
-
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import org.apache.commons.io.FileUtils;
 
 public abstract class BaseGeneratorTest {
 
   public static PluginProtos.CodeGeneratorRequest loadJson(String resource) throws Exception {
+    return loadJson(resource, null);
+  }
+
+  public static PluginProtos.CodeGeneratorRequest loadJson(String resource, String parameterOverride) throws Exception {
     try (InputStream is = BaseGeneratorTest.class.getClassLoader().getResource(resource).openStream()) {
       PluginProtos.CodeGeneratorRequest.Builder b = PluginProtos.CodeGeneratorRequest.newBuilder();
       JsonFormat.parser().merge(new InputStreamReader(is), b);
+      if (parameterOverride != null) {
+        b.setParameter(parameterOverride);
+      }
       return b.build();
     }
   }

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jaxrs/HelloworldGeneratorTest.java
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jaxrs/HelloworldGeneratorTest.java
@@ -28,4 +28,20 @@ public class HelloworldGeneratorTest extends BaseGeneratorTest {
     Approvals.verifyAll("", response.getFileList().stream().map(File::getContent).collect(toList()));
     response.getFileList().forEach(BaseGeneratorTest::assertParses);
   }
+
+  @Test
+  public void test_GenerateWithRequest() throws Exception {
+    PluginProtos.CodeGeneratorRequest request = loadJson("helloworld.jaxrs.json", "target=server,type=jaxrs,request=HelloWorld");
+
+    Plugin plugin = new Plugin(request);
+    PluginProtos.CodeGeneratorResponse response = plugin.process();
+
+    assertNotNull(response);
+    assertEquals(2, response.getFileCount());
+    assertEquals(response.getFile(0).getName(), "com/example/helloworld/RpcHelloWorld.java");
+    assertEquals(response.getFile(1).getName(), "com/example/helloworld/RpcHelloWorldResource.java");
+
+    Approvals.verifyAll("", response.getFileList().stream().map(File::getContent).collect(toList()));
+    response.getFileList().forEach(BaseGeneratorTest::assertParses);
+  }
 }

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jaxrs/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jaxrs/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
@@ -1,0 +1,91 @@
+[0] = package com.example.helloworld;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface RpcHelloWorld {
+  Helloworld.HelloResp handleHello(HttpServletRequest request, Helloworld.HelloReq in);
+
+  Helloworld.HelloResp handleHelloAgain(HttpServletRequest request, Helloworld.HelloReq in);
+}
+
+[1] = package com.example.helloworld;
+
+import com.google.protobuf.util.JsonFormat;
+import java.io.InputStreamReader;
+import java.lang.Exception;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+
+@Path("/twirp/com.example.helloworld.HelloWorld")
+public class RpcHelloWorldResource {
+  private final RpcHelloWorld service;
+
+  public RpcHelloWorldResource(RpcHelloWorld service) {
+    this.service = service;
+  }
+
+  @POST
+  @Path("/Hello")
+  public void handleHello(@Context HttpServletRequest request,
+      @Context HttpServletResponse response) throws Exception {
+    boolean json = false;
+    final Helloworld.HelloReq data;
+    if (request.getContentType().equals("application/protobuf")) {
+      data = Helloworld.HelloReq.parseFrom(request.getInputStream());
+    } else if (request.getContentType().startsWith("application/json")) {
+      json = true;
+      Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      response.setStatus(415);
+      response.flushBuffer();
+      return;
+    }
+    Helloworld.HelloResp retval = service.handleHello(request, data);
+    response.setStatus(200);
+    if (json) {
+      response.setContentType("application/json; charset=utf-8");
+      response.getOutputStream().write(JsonFormat.printer().omittingInsignificantWhitespace().print(retval).getBytes(StandardCharsets.UTF_8));
+    } else {
+      response.setContentType("application/protobuf");
+      retval.writeTo(response.getOutputStream());
+    }
+    response.flushBuffer();
+  }
+
+  @POST
+  @Path("/HelloAgain")
+  public void handleHelloAgain(@Context HttpServletRequest request,
+      @Context HttpServletResponse response) throws Exception {
+    boolean json = false;
+    final Helloworld.HelloReq data;
+    if (request.getContentType().equals("application/protobuf")) {
+      data = Helloworld.HelloReq.parseFrom(request.getInputStream());
+    } else if (request.getContentType().startsWith("application/json")) {
+      json = true;
+      Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      response.setStatus(415);
+      response.flushBuffer();
+      return;
+    }
+    Helloworld.HelloResp retval = service.handleHelloAgain(request, data);
+    response.setStatus(200);
+    if (json) {
+      response.setContentType("application/json; charset=utf-8");
+      response.getOutputStream().write(JsonFormat.printer().omittingInsignificantWhitespace().print(retval).getBytes(StandardCharsets.UTF_8));
+    } else {
+      response.setContentType("application/protobuf");
+      retval.writeTo(response.getOutputStream());
+    }
+    response.flushBuffer();
+  }
+}
+

--- a/plugin/src/test/java/com/flit/protoc/gen/server/spring/HelloworldGeneratorTest.java
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/spring/HelloworldGeneratorTest.java
@@ -1,19 +1,34 @@
 package com.flit.protoc.gen.server.spring;
 
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.flit.protoc.Plugin;
 import com.flit.protoc.gen.BaseGeneratorTest;
 import com.google.protobuf.compiler.PluginProtos;
 import org.approvaltests.Approvals;
 import org.junit.Test;
 
-import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 public class HelloworldGeneratorTest extends BaseGeneratorTest {
 
   @Test public void test_Generate() throws Exception {
     PluginProtos.CodeGeneratorRequest request = loadJson("helloworld.spring.json");
+
+    Plugin plugin = new Plugin(request);
+    PluginProtos.CodeGeneratorResponse response = plugin.process();
+
+    assertNotNull(response);
+    assertEquals(2, response.getFileCount());
+    assertEquals(response.getFile(0).getName(), "com/example/helloworld/RpcHelloWorld.java");
+    assertEquals(response.getFile(1).getName(), "com/example/helloworld/RpcHelloWorldController.java");
+
+    Approvals.verifyAll("", response.getFileList().stream().map(f -> f.getContent()).collect(toList()));
+    response.getFileList().forEach(f -> assertParses(f));
+  }
+
+  @Test public void test_GenerateWithRequest() throws Exception {
+    PluginProtos.CodeGeneratorRequest request = loadJson("helloworld.spring.json", "target=server,type=spring,request=HelloWorld");
 
     Plugin plugin = new Plugin(request);
     PluginProtos.CodeGeneratorResponse response = plugin.process();

--- a/plugin/src/test/java/com/flit/protoc/gen/server/spring/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/spring/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
@@ -1,0 +1,82 @@
+[0] = package com.example.helloworld;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface RpcHelloWorld {
+  Helloworld.HelloResp handleHello(HttpServletRequest request, Helloworld.HelloReq in);
+
+  Helloworld.HelloResp handleHelloAgain(HttpServletRequest request, Helloworld.HelloReq in);
+}
+
+[1] = package com.example.helloworld;
+
+import com.google.protobuf.util.JsonFormat;
+import java.io.InputStreamReader;
+import java.lang.Exception;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RpcHelloWorldController {
+  @Autowired
+  private RpcHelloWorld service;
+
+  @PostMapping("/twirp/com.example.helloworld.HelloWorld/Hello")
+  public void handleHello(HttpServletRequest request, HttpServletResponse response) throws
+      Exception {
+    boolean json = false;
+    final Helloworld.HelloReq data;
+    if (request.getContentType().equals("application/protobuf")) {
+      data = Helloworld.HelloReq.parseFrom(request.getInputStream());
+    } else if (request.getContentType().startsWith("application/json")) {
+      json = true;
+      Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      response.setStatus(415);
+      return;
+    }
+    Helloworld.HelloResp retval = service.handleHello(request, data);
+    response.setStatus(200);
+    if (json) {
+      response.setContentType("application/json; charset=utf-8");
+      response.getOutputStream().write(JsonFormat.printer().omittingInsignificantWhitespace().print(retval).getBytes(StandardCharsets.UTF_8));
+    } else {
+      response.setContentType("application/protobuf");
+      retval.writeTo(response.getOutputStream());
+    }
+  }
+
+  @PostMapping("/twirp/com.example.helloworld.HelloWorld/HelloAgain")
+  public void handleHelloAgain(HttpServletRequest request, HttpServletResponse response) throws
+      Exception {
+    boolean json = false;
+    final Helloworld.HelloReq data;
+    if (request.getContentType().equals("application/protobuf")) {
+      data = Helloworld.HelloReq.parseFrom(request.getInputStream());
+    } else if (request.getContentType().startsWith("application/json")) {
+      json = true;
+      Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      response.setStatus(415);
+      return;
+    }
+    Helloworld.HelloResp retval = service.handleHelloAgain(request, data);
+    response.setStatus(200);
+    if (json) {
+      response.setContentType("application/json; charset=utf-8");
+      response.getOutputStream().write(JsonFormat.printer().omittingInsignificantWhitespace().print(retval).getBytes(StandardCharsets.UTF_8));
+    } else {
+      response.setContentType("application/protobuf");
+      retval.writeTo(response.getOutputStream());
+    }
+  }
+}
+

--- a/plugin/src/test/java/com/flit/protoc/gen/server/undertow/HelloworldGeneratorTest.java
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/undertow/HelloworldGeneratorTest.java
@@ -1,19 +1,34 @@
 package com.flit.protoc.gen.server.undertow;
 
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.flit.protoc.Plugin;
 import com.flit.protoc.gen.BaseGeneratorTest;
 import com.google.protobuf.compiler.PluginProtos;
 import org.approvaltests.Approvals;
 import org.junit.Test;
 
-import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 public class HelloworldGeneratorTest extends BaseGeneratorTest {
 
   @Test public void test_Generate() throws Exception {
     PluginProtos.CodeGeneratorRequest request = loadJson("helloworld.undertow.json");
+
+    Plugin plugin = new Plugin(request);
+    PluginProtos.CodeGeneratorResponse response = plugin.process();
+
+    assertNotNull(response);
+    assertEquals(2, response.getFileCount());
+    assertEquals(response.getFile(0).getName(), "com/example/helloworld/RpcHelloWorld.java");
+    assertEquals(response.getFile(1).getName(), "com/example/helloworld/RpcHelloWorldHandler.java");
+
+    Approvals.verifyAll("", response.getFileList().stream().map(f -> f.getContent()).collect(toList()));
+    response.getFileList().forEach(f -> assertParses(f));
+  }
+
+  @Test public void test_GenerateWithRequest() throws Exception {
+    PluginProtos.CodeGeneratorRequest request = loadJson("helloworld.undertow.json", "target=server,type=undertow,request=HelloWorld");
 
     Plugin plugin = new Plugin(request);
     PluginProtos.CodeGeneratorResponse response = plugin.process();

--- a/plugin/src/test/java/com/flit/protoc/gen/server/undertow/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/undertow/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
@@ -1,0 +1,117 @@
+[0] = package com.example.helloworld;
+
+import io.undertow.server.HttpServerExchange;
+
+public interface RpcHelloWorld {
+  Helloworld.HelloResp handleHello(HttpServerExchange request, Helloworld.HelloReq in);
+
+  Helloworld.HelloResp handleHelloAgain(HttpServerExchange request, Helloworld.HelloReq in);
+}
+
+[1] = package com.example.helloworld;
+
+import com.flit.runtime.ErrorCode;
+import com.flit.runtime.FlitException;
+import com.flit.runtime.undertow.ErrorWriter;
+import com.flit.runtime.undertow.FlitHandler;
+import com.google.protobuf.util.JsonFormat;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import java.io.InputStreamReader;
+import java.lang.Exception;
+import java.lang.Override;
+import java.lang.String;
+import java.nio.charset.StandardCharsets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RpcHelloWorldHandler implements HttpHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RpcHelloWorldHandler.class);
+
+  public static final String ROUTE = "/twirp/com.example.helloworld.HelloWorld";
+
+  private final RpcHelloWorld service;
+
+  private final ErrorWriter errorWriter;
+
+  public RpcHelloWorldHandler(RpcHelloWorld service) {
+    this.service = service;
+    this.errorWriter = new ErrorWriter();
+  }
+
+  @Override
+  public void handleRequest(HttpServerExchange exchange) throws Exception {
+    if (exchange.isInIoThread()) {
+      exchange.dispatch(this);
+      return;
+    }
+    exchange.startBlocking();
+    String method = exchange.getAttachment(FlitHandler.KEY_METHOD);
+    try {
+      switch (method) {
+        case "Hello": handleHello(exchange); break;
+        case "HelloAgain": handleHelloAgain(exchange); break;
+        default: throw FlitException.builder().withErrorCode(ErrorCode.BAD_ROUTE).withMessage("No such route").build();
+      }
+    } catch (FlitException e) {
+      errorWriter.write(e, exchange);
+    } catch (Exception e) {
+      LOGGER.error("Exception caught at handler: {}", e.getMessage(), e);
+      errorWriter.write(e, exchange);
+    }
+  }
+
+  private void handleHello(HttpServerExchange exchange) throws Exception {
+    boolean json = false;
+    final Helloworld.HelloReq data;
+    final String contentType = exchange.getRequestHeaders().get(Headers.CONTENT_TYPE).getFirst();
+    if (contentType.equals("application/protobuf")) {
+      data = Helloworld.HelloReq.parseFrom(exchange.getInputStream());
+    } else if (contentType.startsWith("application/json")) {
+      json = true;
+      Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      exchange.setStatusCode(415);
+      return;
+    }
+    Helloworld.HelloResp response = service.handleHello(exchange, data);
+    exchange.setStatusCode(200);
+    if (json) {
+      exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json; charset=utf-8");
+      exchange.getResponseSender().send(JsonFormat.printer().omittingInsignificantWhitespace().print(response));
+    } else {
+      exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/protobuf");
+      response.writeTo(exchange.getOutputStream());
+    }
+  }
+
+  private void handleHelloAgain(HttpServerExchange exchange) throws Exception {
+    boolean json = false;
+    final Helloworld.HelloReq data;
+    final String contentType = exchange.getRequestHeaders().get(Headers.CONTENT_TYPE).getFirst();
+    if (contentType.equals("application/protobuf")) {
+      data = Helloworld.HelloReq.parseFrom(exchange.getInputStream());
+    } else if (contentType.startsWith("application/json")) {
+      json = true;
+      Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      exchange.setStatusCode(415);
+      return;
+    }
+    Helloworld.HelloResp response = service.handleHelloAgain(exchange, data);
+    exchange.setStatusCode(200);
+    if (json) {
+      exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json; charset=utf-8");
+      exchange.getResponseSender().send(JsonFormat.printer().omittingInsignificantWhitespace().print(response));
+    } else {
+      exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/protobuf");
+      response.writeTo(exchange.getOutputStream());
+    }
+  }
+}
+

--- a/runtime/undertow/build.gradle
+++ b/runtime/undertow/build.gradle
@@ -33,7 +33,11 @@ dependencies {
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:${protobufVersion}"
+    if (project.hasProperty('protoc_platform')) {
+      artifact = "com.google.protobuf:protoc:$protobufVersion:${protoc_platform}"
+    } else {
+      artifact = "com.google.protobuf:protoc:$protobufVersion"
+    }
   }
   plugins {
     flit {


### PR DESCRIPTION
Optionally pass request types into service interface via flag `request=SampleService` which takes a comma separated list of names. Works for all server types.

```java
SampleResponse retval = service.handleExample(request, data);
```

```java
public interface RpcSampleService {
  SampleResponse handleExample(HttpServletRequest request, SampleRequest in);
}
```

/cc https://github.com/github/data-pipelines/issues/1471
/cc @github/data-pipelines 