### PR TITLE
Fixed gradle warnings.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.3'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:4.0.3'
     }
 }
 
@@ -37,11 +37,12 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'ch.qos.logback:logback-classic:1.2.3'
     compile 'commons-io:commons-io:2.5'
-    compile 'com.google.protobuf:protobuf-java:3.5.1'
-    compile 'com.google.protobuf:protobuf-java-util:3.5.1'
+    compile 'com.google.protobuf:protobuf-java:3.15.8'
+    compile 'com.google.protobuf:protobuf-java-util:3.15.8'
     compile 'com.squareup:javapoet:1.11.1'
 
     compileOnly('org.projectlombok:lombok:+')
+    annotationProcessor 'org.projectlombok:lombok:+'
 
     testCompile 'com.github.javaparser:javaparser-core:3.6.9'
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Bump versions: gradle wrapper 4.8 -> 4.10, protobuf-java 3.5.1 -> 3.15.8, gradle shadow plugin 2.0.3 -> 4.0.3