### PR TITLE
Fix bug with parsing multiple request parameters

### DIFF
--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,1 +1,1 @@
-version=1.2.1
+version=1.2.2

--- a/plugin/src/main/java/com/flit/protoc/Plugin.java
+++ b/plugin/src/main/java/com/flit/protoc/Plugin.java
@@ -72,7 +72,7 @@ public class Plugin {
     if (requestServices == null) {
       return Collections.emptyList();
     } else {
-      return Arrays.asList(requestServices.getValue().split(","));
+      return Arrays.asList(requestServices.getValue().split(";"));
     }
   }
 }


### PR DESCRIPTION
Since the parameters are already parsed by `,` replace separator with `;` instead.

/cc @github/data-pipelines 