### PR TITLE
add jakarta implementation for dropwizard 4x change

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It supports the generation of Java based servers with the following flavours sup
 + [Spring Boot/Spring MVC](https://spring.io/projects/spring-boot "Spring Boot")
 + [Undertow](http://undertow.io/ "Undertow")
 + JAX-RS ([Jersey](https://eclipse-ee4j.github.io/jersey/), [Apache CFX](http://cxf.apache.org/))
++ [Jakarta EE](https://jakarta.ee/ "Jakarta") 
 
 ## Building & Running
 
@@ -24,13 +25,14 @@ To test you will need an installation of the [protocol buffers compiler](https:/
 
 The project is split into the following modules:
 
-| Module            |   Description                                         |
-|:------------------|:------------------------------------------------------|
-| `plugin`          | The `protoc` plugin                                   |
-| `runtime:core`    | Core functionality required by generated code         |
-| `runtime:jaxrs`   | Runtime library for JAX-RS servers                    |
-| `runtime:spring`  | Runtime library for Spring MVC/Boot servers           |
-| `runtime:undertow`| Runtime library for Undertow servers                  |
+| Module             | Description                                   |
+|:-------------------|:----------------------------------------------|
+| `plugin`           | The `protoc` plugin                           |
+| `runtime:core`     | Core functionality required by generated code |
+| `runtime:jakarta`  | Runtime library for Jakarta servers           |
+| `runtime:jaxrs`    | Runtime library for JAX-RS servers            |
+| `runtime:spring`   | Runtime library for Spring MVC/Boot servers   |
+| `runtime:undertow` | Runtime library for Undertow servers          |
 
 
 ### Build
@@ -63,12 +65,12 @@ The plugin is executed as part of a protoc compilation step:
 
 The flit plugin accepts the following plugin parameters:
 
-| Name      | Required  | Type                              | Description                                            |
-|:----------|:---------:|:----------------------------------|:-------------------------------------------------------|
-| `target`  | Y         | `enum[server]`                    | The type of target to generate e.g. server, client etc |
-| `type`    | Y         | `enum[spring,undertow,boot,jaxrs]`| Type of target to generate                             |
-| `context` | N         | `string`                          | Base context for routing, default is `/twirp`          |
-| `request` | N         | `string`                          | If the request parameter should pass to the service    |
+| Name      | Required  | Type                                       | Description                                            |
+|:----------|:---------:|:-------------------------------------------|:-------------------------------------------------------|
+| `target`  | Y         | `enum[server]`                             | The type of target to generate e.g. server, client etc |
+| `type`    | Y         | `enum[spring,undertow,boot,jakarta,jaxrs]` | Type of target to generate                             |
+| `context` | N         | `string`                                   | Base context for routing, default is `/twirp`          |
+| `request` | N         | `string`                                   | If the request parameter should pass to the service    |
 
 # Development
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ allprojects {
 
     ext {
         // third party
+        jakartaservletapiVersion = "5.0.0"
+        jakartawsrsapiVersion = "3.0.0"
         javapoetVersion = "1.13.0"
         javaxservletapiVersion = "4.0.1"
         javaxwsrsapiVersion = "2.1.1"
@@ -25,7 +27,8 @@ allprojects {
         // testing
         approvaltestsVersion = "18.5.0"
         javaparserVersion = "3.25.2"
-        jerseyCommonVersion = "2.22.2"
+        jerseyCommonJavaxVersion = "2.22.2"
+        jerseyCommonJakartaVersion = "3.1.1"
         junitJupiterVersion = "5.9.2"
         mockitoVersion = "5.2.0"
     }

--- a/plugin/src/main/java/com/flit/protoc/Plugin.java
+++ b/plugin/src/main/java/com/flit/protoc/Plugin.java
@@ -6,6 +6,7 @@ import static com.flit.protoc.Parameter.PARAM_TYPE;
 
 import com.flit.protoc.gen.Generator;
 import com.flit.protoc.gen.GeneratorException;
+import com.flit.protoc.gen.server.jakarta.JakartaGenerator;
 import com.flit.protoc.gen.server.jaxrs.JaxrsGenerator;
 import com.flit.protoc.gen.server.spring.SpringGenerator;
 import com.flit.protoc.gen.server.undertow.UndertowGenerator;
@@ -59,6 +60,8 @@ public class Plugin {
             return new UndertowGenerator(requestServices);
           case "jaxrs":
             return new JaxrsGenerator(requestServices);
+          case "jakarta":
+            return new JakartaGenerator(requestServices);
           default:
             throw new GeneratorException("Unknown server type: " + params.get(PARAM_TYPE).getValue());
         }

--- a/plugin/src/main/java/com/flit/protoc/gen/server/jakarta/JakartaGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/jakarta/JakartaGenerator.java
@@ -1,0 +1,29 @@
+package com.flit.protoc.gen.server.jakarta;
+
+import static com.flit.protoc.gen.server.jakarta.RpcGenerator.HttpServletRequest;
+
+import com.flit.protoc.gen.server.BaseGenerator;
+import com.flit.protoc.gen.server.BaseServerGenerator;
+import com.flit.protoc.gen.server.TypeMapper;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto;
+import com.squareup.javapoet.TypeName;
+import java.util.List;
+
+public class JakartaGenerator extends BaseServerGenerator {
+
+  public JakartaGenerator(List<String> requestServices) {
+    super(requestServices);
+  }
+
+  @Override
+  protected BaseGenerator getRpcGenerator(FileDescriptorProto proto, ServiceDescriptorProto service,
+      String context, TypeMapper mapper) {
+    return new RpcGenerator(proto, service, context, mapper, isRequestBasedClass(service));
+  }
+
+  @Override
+  protected TypeName getHttpRequestTypeName() {
+    return HttpServletRequest;
+  }
+}

--- a/plugin/src/main/java/com/flit/protoc/gen/server/jakarta/RpcGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/jakarta/RpcGenerator.java
@@ -1,4 +1,4 @@
-package com.flit.protoc.gen.server.jaxrs;
+package com.flit.protoc.gen.server.jakarta;
 
 import com.flit.protoc.gen.server.BaseGenerator;
 import com.flit.protoc.gen.server.TypeMapper;
@@ -20,11 +20,11 @@ import javax.lang.model.element.Modifier;
 
 public class RpcGenerator extends BaseGenerator {
 
-  static final ClassName PATH = ClassName.bestGuess("javax.ws.rs.Path");
-  static final ClassName POST = ClassName.bestGuess("javax.ws.rs.POST");
-  static final ClassName CONTEXT = ClassName.bestGuess("javax.ws.rs.core.Context");
-  static final ClassName HttpServletRequest = ClassName.bestGuess("javax.servlet.http.HttpServletRequest");
-  static final ClassName HttpServletResponse = ClassName.bestGuess("javax.servlet.http.HttpServletResponse");
+  static final ClassName PATH = ClassName.bestGuess("jakarta.ws.rs.Path");
+  static final ClassName POST = ClassName.bestGuess("jakarta.ws.rs.POST");
+  static final ClassName CONTEXT = ClassName.bestGuess("jakarta.ws.rs.core.Context");
+  static final ClassName HttpServletRequest = ClassName.bestGuess("jakarta.servlet.http.HttpServletRequest");
+  static final ClassName HttpServletResponse = ClassName.bestGuess("jakarta.servlet.http.HttpServletResponse");
 
   private final Builder rpcResource;
   private final boolean passRequest;

--- a/plugin/src/main/java/com/flit/protoc/gen/server/spring/RpcGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/spring/RpcGenerator.java
@@ -14,11 +14,11 @@ import java.util.List;
 
 class RpcGenerator extends BaseGenerator {
 
-  public static final ClassName RestController = ClassName.bestGuess("org.springframework.web.bind.annotation.RestController");
-  public static final ClassName Autowired = ClassName.bestGuess("org.springframework.beans.factory.annotation.Autowired");
-  public static final ClassName PostMapping = ClassName.bestGuess("org.springframework.web.bind.annotation.PostMapping");
-  public static final ClassName HttpServletRequest = ClassName.bestGuess("javax.servlet.http.HttpServletRequest");
-  public static final ClassName HttpServletResponse = ClassName.bestGuess("javax.servlet.http.HttpServletResponse");
+  static final ClassName RestController = ClassName.bestGuess("org.springframework.web.bind.annotation.RestController");
+  static final ClassName Autowired = ClassName.bestGuess("org.springframework.beans.factory.annotation.Autowired");
+  static final ClassName PostMapping = ClassName.bestGuess("org.springframework.web.bind.annotation.PostMapping");
+  static final ClassName HttpServletRequest = ClassName.bestGuess("javax.servlet.http.HttpServletRequest");
+  static final ClassName HttpServletResponse = ClassName.bestGuess("javax.servlet.http.HttpServletResponse");
 
   private final String context;
   private final TypeSpec.Builder rpcController;

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/ContextGeneratorTest.java
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/ContextGeneratorTest.java
@@ -1,0 +1,67 @@
+package com.flit.protoc.gen.server.jakarta;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.flit.protoc.Plugin;
+import com.flit.protoc.gen.BaseGeneratorTest;
+import com.google.protobuf.compiler.PluginProtos;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the generation of a service that has core definition imported from another file
+ */
+public class ContextGeneratorTest extends BaseGeneratorTest {
+
+  @Test
+  public void test_GenerateWithMissingRoot() throws Exception {
+    test_Route("context.missing.jakarta.json", "/twirp/com.example.context.NullService");
+  }
+
+  @Test
+  public void test_GenerateWithEmptyRoot() throws Exception {
+    test_Route("context.empty.jakarta.json", "/twirp/com.example.context.NullService");
+  }
+
+  @Test
+  public void test_GenerateWithSlashOnlyRoot() throws Exception {
+    test_Route("context.slash.jakarta.json", "/com.example.context.NullService");
+  }
+
+  @Test
+  public void test_GenerateWithSlashRoot() throws Exception {
+    test_Route("context.root.jakarta.json", "/root/com.example.context.NullService");
+  }
+
+  @Test
+  public void test_GenerateWithNameRoot() throws Exception {
+    test_Route("context.name.jakarta.json", "/fibble/com.example.context.NullService");
+  }
+
+  private void test_Route(String file, String route) throws Exception {
+    PluginProtos.CodeGeneratorRequest request = loadJson(file);
+
+    Plugin plugin = new Plugin(request);
+    PluginProtos.CodeGeneratorResponse response = plugin.process();
+
+    assertNotNull(response);
+    assertEquals(2, response.getFileCount());
+
+    Map<String, File> files = response.getFileList()
+        .stream()
+        .collect(Collectors
+            .toMap(File::getName, Function.identity()));
+
+    assertTrue(files.containsKey("com/example/context/rpc/RpcNullService.java"));
+    assertTrue(files.containsKey("com/example/context/rpc/RpcNullServiceResource.java"));
+
+    assertTrue(files.get("com/example/context/rpc/RpcNullServiceResource.java")
+        .getContent()
+        .contains(String.format("@Path(\"%s\")", route)));
+  }
+}

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/HelloworldGeneratorTest.java
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/HelloworldGeneratorTest.java
@@ -1,0 +1,47 @@
+package com.flit.protoc.gen.server.jakarta;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.flit.protoc.Plugin;
+import com.flit.protoc.gen.BaseGeneratorTest;
+import com.google.protobuf.compiler.PluginProtos;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File;
+import org.approvaltests.Approvals;
+import org.junit.jupiter.api.Test;
+
+public class HelloworldGeneratorTest extends BaseGeneratorTest {
+
+  @Test
+  public void test_Generate() throws Exception {
+    PluginProtos.CodeGeneratorRequest request = loadJson("helloworld.jakarta.json");
+
+    Plugin plugin = new Plugin(request);
+    PluginProtos.CodeGeneratorResponse response = plugin.process();
+
+    assertNotNull(response);
+    assertEquals(2, response.getFileCount());
+    assertEquals(response.getFile(0).getName(), "com/example/helloworld/RpcHelloWorld.java");
+    assertEquals(response.getFile(1).getName(), "com/example/helloworld/RpcHelloWorldResource.java");
+
+    Approvals.verifyAll("", response.getFileList().stream().map(File::getContent).collect(toList()));
+    response.getFileList().forEach(BaseGeneratorTest::assertParses);
+  }
+
+  @Test
+  public void test_GenerateWithRequest() throws Exception {
+    PluginProtos.CodeGeneratorRequest request = loadJson("helloworld.jakarta.json", "target=server,type=jakarta,request=HelloWorld");
+
+    Plugin plugin = new Plugin(request);
+    PluginProtos.CodeGeneratorResponse response = plugin.process();
+
+    assertNotNull(response);
+    assertEquals(2, response.getFileCount());
+    assertEquals(response.getFile(0).getName(), "com/example/helloworld/RpcHelloWorld.java");
+    assertEquals(response.getFile(1).getName(), "com/example/helloworld/RpcHelloWorldResource.java");
+
+    Approvals.verifyAll("", response.getFileList().stream().map(File::getContent).collect(toList()));
+    response.getFileList().forEach(BaseGeneratorTest::assertParses);
+  }
+}

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/HelloworldGeneratorTest.test_Generate.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/HelloworldGeneratorTest.test_Generate.approved.txt
@@ -1,0 +1,89 @@
+[0] = package com.example.helloworld;
+
+public interface RpcHelloWorld {
+  Helloworld.HelloResp handleHello(Helloworld.HelloReq in);
+
+  Helloworld.HelloResp handleHelloAgain(Helloworld.HelloReq in);
+}
+
+[1] = package com.example.helloworld;
+
+import com.google.protobuf.util.JsonFormat;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import java.io.InputStreamReader;
+import java.lang.Exception;
+import java.nio.charset.StandardCharsets;
+
+@Path("/twirp/com.example.helloworld.HelloWorld")
+public class RpcHelloWorldResource {
+  private final RpcHelloWorld service;
+
+  public RpcHelloWorldResource(RpcHelloWorld service) {
+    this.service = service;
+  }
+
+  @POST
+  @Path("/Hello")
+  public void handleHello(@Context HttpServletRequest request,
+      @Context HttpServletResponse response) throws Exception {
+    boolean json = false;
+    final Helloworld.HelloReq data;
+    if (request.getContentType().equals("application/protobuf")) {
+      data = Helloworld.HelloReq.parseFrom(request.getInputStream());
+    } else if (request.getContentType().startsWith("application/json")) {
+      json = true;
+      Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      response.setStatus(415);
+      response.flushBuffer();
+      return;
+    }
+    Helloworld.HelloResp retval = service.handleHello(data);
+    response.setStatus(200);
+    if (json) {
+      response.setContentType("application/json; charset=utf-8");
+      response.getOutputStream().write(JsonFormat.printer().omittingInsignificantWhitespace().print(retval).getBytes(StandardCharsets.UTF_8));
+    } else {
+      response.setContentType("application/protobuf");
+      retval.writeTo(response.getOutputStream());
+    }
+    response.flushBuffer();
+  }
+
+  @POST
+  @Path("/HelloAgain")
+  public void handleHelloAgain(@Context HttpServletRequest request,
+      @Context HttpServletResponse response) throws Exception {
+    boolean json = false;
+    final Helloworld.HelloReq data;
+    if (request.getContentType().equals("application/protobuf")) {
+      data = Helloworld.HelloReq.parseFrom(request.getInputStream());
+    } else if (request.getContentType().startsWith("application/json")) {
+      json = true;
+      Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      response.setStatus(415);
+      response.flushBuffer();
+      return;
+    }
+    Helloworld.HelloResp retval = service.handleHelloAgain(data);
+    response.setStatus(200);
+    if (json) {
+      response.setContentType("application/json; charset=utf-8");
+      response.getOutputStream().write(JsonFormat.printer().omittingInsignificantWhitespace().print(retval).getBytes(StandardCharsets.UTF_8));
+    } else {
+      response.setContentType("application/protobuf");
+      retval.writeTo(response.getOutputStream());
+    }
+    response.flushBuffer();
+  }
+}
+

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
@@ -1,0 +1,91 @@
+[0] = package com.example.helloworld;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface RpcHelloWorld {
+  Helloworld.HelloResp handleHello(HttpServletRequest request, Helloworld.HelloReq in);
+
+  Helloworld.HelloResp handleHelloAgain(HttpServletRequest request, Helloworld.HelloReq in);
+}
+
+[1] = package com.example.helloworld;
+
+import com.google.protobuf.util.JsonFormat;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import java.io.InputStreamReader;
+import java.lang.Exception;
+import java.nio.charset.StandardCharsets;
+
+@Path("/twirp/com.example.helloworld.HelloWorld")
+public class RpcHelloWorldResource {
+  private final RpcHelloWorld service;
+
+  public RpcHelloWorldResource(RpcHelloWorld service) {
+    this.service = service;
+  }
+
+  @POST
+  @Path("/Hello")
+  public void handleHello(@Context HttpServletRequest request,
+      @Context HttpServletResponse response) throws Exception {
+    boolean json = false;
+    final Helloworld.HelloReq data;
+    if (request.getContentType().equals("application/protobuf")) {
+      data = Helloworld.HelloReq.parseFrom(request.getInputStream());
+    } else if (request.getContentType().startsWith("application/json")) {
+      json = true;
+      Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      response.setStatus(415);
+      response.flushBuffer();
+      return;
+    }
+    Helloworld.HelloResp retval = service.handleHello(request, data);
+    response.setStatus(200);
+    if (json) {
+      response.setContentType("application/json; charset=utf-8");
+      response.getOutputStream().write(JsonFormat.printer().omittingInsignificantWhitespace().print(retval).getBytes(StandardCharsets.UTF_8));
+    } else {
+      response.setContentType("application/protobuf");
+      retval.writeTo(response.getOutputStream());
+    }
+    response.flushBuffer();
+  }
+
+  @POST
+  @Path("/HelloAgain")
+  public void handleHelloAgain(@Context HttpServletRequest request,
+      @Context HttpServletResponse response) throws Exception {
+    boolean json = false;
+    final Helloworld.HelloReq data;
+    if (request.getContentType().equals("application/protobuf")) {
+      data = Helloworld.HelloReq.parseFrom(request.getInputStream());
+    } else if (request.getContentType().startsWith("application/json")) {
+      json = true;
+      Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      response.setStatus(415);
+      response.flushBuffer();
+      return;
+    }
+    Helloworld.HelloResp retval = service.handleHelloAgain(request, data);
+    response.setStatus(200);
+    if (json) {
+      response.setContentType("application/json; charset=utf-8");
+      response.getOutputStream().write(JsonFormat.printer().omittingInsignificantWhitespace().print(retval).getBytes(StandardCharsets.UTF_8));
+    } else {
+      response.setContentType("application/protobuf");
+      retval.writeTo(response.getOutputStream());
+    }
+    response.flushBuffer();
+  }
+}
+

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/StatusGeneratorTest.java
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/StatusGeneratorTest.java
@@ -1,0 +1,36 @@
+package com.flit.protoc.gen.server.jakarta;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.flit.protoc.Plugin;
+import com.flit.protoc.gen.BaseGeneratorTest;
+import com.google.protobuf.compiler.PluginProtos;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File;
+import org.approvaltests.Approvals;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the generation of a service that has core definition imported from another file
+ */
+public class StatusGeneratorTest extends BaseGeneratorTest {
+
+  @Test
+  public void test_Generate() throws Exception {
+    PluginProtos.CodeGeneratorRequest request = loadJson("status.jakarta.json");
+
+    Plugin plugin = new Plugin(request);
+    PluginProtos.CodeGeneratorResponse response = plugin.process();
+
+    assertNotNull(response);
+    assertEquals(2, response.getFileCount());
+
+    assertEquals(response.getFile(0).getName(), "com/example/helloworld/RpcStatus.java");
+    assertEquals(response.getFile(1).getName(), "com/example/helloworld/RpcStatusResource.java");
+
+    Approvals.verifyAll("", response.getFileList().stream().map(File::getContent).collect(toList()));
+    response.getFileList().forEach(BaseGeneratorTest::assertParses);
+  }
+
+}

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/StatusGeneratorTest.test_Generate.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/StatusGeneratorTest.test_Generate.approved.txt
@@ -1,0 +1,57 @@
+[0] = package com.example.helloworld;
+
+public interface RpcStatus {
+  StatusOuterClass.StatusResponse handleGetStatus(Core.Empty in);
+}
+
+[1] = package com.example.helloworld;
+
+import com.google.protobuf.util.JsonFormat;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Context;
+import java.io.InputStreamReader;
+import java.lang.Exception;
+import java.nio.charset.StandardCharsets;
+
+@Path("/twirp/com.example.helloworld.Status")
+public class RpcStatusResource {
+  private final RpcStatus service;
+
+  public RpcStatusResource(RpcStatus service) {
+    this.service = service;
+  }
+
+  @POST
+  @Path("/GetStatus")
+  public void handleGetStatus(@Context HttpServletRequest request,
+      @Context HttpServletResponse response) throws Exception {
+    boolean json = false;
+    final Core.Empty data;
+    if (request.getContentType().equals("application/protobuf")) {
+      data = Core.Empty.parseFrom(request.getInputStream());
+    } else if (request.getContentType().startsWith("application/json")) {
+      json = true;
+      Core.Empty.Builder builder = Core.Empty.newBuilder();
+      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      data = builder.build();
+    } else {
+      response.setStatus(415);
+      response.flushBuffer();
+      return;
+    }
+    StatusOuterClass.StatusResponse retval = service.handleGetStatus(data);
+    response.setStatus(200);
+    if (json) {
+      response.setContentType("application/json; charset=utf-8");
+      response.getOutputStream().write(JsonFormat.printer().omittingInsignificantWhitespace().print(retval).getBytes(StandardCharsets.UTF_8));
+    } else {
+      response.setContentType("application/protobuf");
+      retval.writeTo(response.getOutputStream());
+    }
+    response.flushBuffer();
+  }
+}
+

--- a/plugin/src/test/resources/context.empty.jakarta.json
+++ b/plugin/src/test/resources/context.empty.jakarta.json
@@ -1,0 +1,29 @@
+{
+  "fileToGenerate": ["context.proto"],
+  "parameter": "target=server,type=jakarta,context=",
+  "compilerVersion": {
+    "major": 3,
+    "minor": 5,
+    "patch": 1,
+    "suffix": ""
+  },
+  "protoFile": [{
+    "name": "context.proto",
+    "package": "com.example.context",
+    "messageType": [{
+      "name": "Empty"
+    }],
+    "service": [{
+      "name": "NullService",
+      "method": [{
+        "name": "SayNull",
+        "inputType": ".com.example.context.Empty",
+        "outputType": ".com.example.context.Empty"
+      }]
+    }],
+    "options": {
+      "javaPackage": "com.example.context.rpc"
+    },
+    "syntax": "proto3"
+  }]
+}

--- a/plugin/src/test/resources/context.missing.jakarta.json
+++ b/plugin/src/test/resources/context.missing.jakarta.json
@@ -1,0 +1,29 @@
+{
+  "fileToGenerate": ["context.proto"],
+  "parameter": "target=server,type=jakarta,context=",
+  "compilerVersion": {
+    "major": 3,
+    "minor": 5,
+    "patch": 1,
+    "suffix": ""
+  },
+  "protoFile": [{
+    "name": "context.proto",
+    "package": "com.example.context",
+    "messageType": [{
+      "name": "Empty"
+    }],
+    "service": [{
+      "name": "NullService",
+      "method": [{
+        "name": "SayNull",
+        "inputType": ".com.example.context.Empty",
+        "outputType": ".com.example.context.Empty"
+      }]
+    }],
+    "options": {
+      "javaPackage": "com.example.context.rpc"
+    },
+    "syntax": "proto3"
+  }]
+}

--- a/plugin/src/test/resources/context.name.jakarta.json
+++ b/plugin/src/test/resources/context.name.jakarta.json
@@ -1,0 +1,29 @@
+{
+  "fileToGenerate": ["context.proto"],
+  "parameter": "target=server,type=jakarta,context=fibble",
+  "compilerVersion": {
+    "major": 3,
+    "minor": 5,
+    "patch": 1,
+    "suffix": ""
+  },
+  "protoFile": [{
+    "name": "context.proto",
+    "package": "com.example.context",
+    "messageType": [{
+      "name": "Empty"
+    }],
+    "service": [{
+      "name": "NullService",
+      "method": [{
+        "name": "SayNull",
+        "inputType": ".com.example.context.Empty",
+        "outputType": ".com.example.context.Empty"
+      }]
+    }],
+    "options": {
+      "javaPackage": "com.example.context.rpc"
+    },
+    "syntax": "proto3"
+  }]
+}

--- a/plugin/src/test/resources/context.root.jakarta.json
+++ b/plugin/src/test/resources/context.root.jakarta.json
@@ -1,0 +1,29 @@
+{
+  "fileToGenerate": ["context.proto"],
+  "parameter": "target=server,type=jakarta,context=/root",
+  "compilerVersion": {
+    "major": 3,
+    "minor": 5,
+    "patch": 1,
+    "suffix": ""
+  },
+  "protoFile": [{
+    "name": "context.proto",
+    "package": "com.example.context",
+    "messageType": [{
+      "name": "Empty"
+    }],
+    "service": [{
+      "name": "NullService",
+      "method": [{
+        "name": "SayNull",
+        "inputType": ".com.example.context.Empty",
+        "outputType": ".com.example.context.Empty"
+      }]
+    }],
+    "options": {
+      "javaPackage": "com.example.context.rpc"
+    },
+    "syntax": "proto3"
+  }]
+}

--- a/plugin/src/test/resources/context.slash.jakarta.json
+++ b/plugin/src/test/resources/context.slash.jakarta.json
@@ -1,0 +1,29 @@
+{
+  "fileToGenerate": ["context.proto"],
+  "parameter": "target=server,type=jakarta,context=/",
+  "compilerVersion": {
+    "major": 3,
+    "minor": 5,
+    "patch": 1,
+    "suffix": ""
+  },
+  "protoFile": [{
+    "name": "context.proto",
+    "package": "com.example.context",
+    "messageType": [{
+      "name": "Empty"
+    }],
+    "service": [{
+      "name": "NullService",
+      "method": [{
+        "name": "SayNull",
+        "inputType": ".com.example.context.Empty",
+        "outputType": ".com.example.context.Empty"
+      }]
+    }],
+    "options": {
+      "javaPackage": "com.example.context.rpc"
+    },
+    "syntax": "proto3"
+  }]
+}

--- a/plugin/src/test/resources/helloworld.jakarta.json
+++ b/plugin/src/test/resources/helloworld.jakarta.json
@@ -1,0 +1,49 @@
+{
+  "fileToGenerate": ["helloworld.proto"],
+  "parameter": "target=server,type=jakarta",
+  "compilerVersion": {
+    "major": 3,
+    "minor": 5,
+    "patch": 1,
+    "suffix": ""
+  },
+  "protoFile": [{
+    "name": "helloworld.proto",
+    "package": "com.example.helloworld",
+    "messageType": [{
+      "name": "HelloReq",
+      "field": [{
+        "name": "subject",
+        "number": 1,
+        "label": "LABEL_OPTIONAL",
+        "type": "TYPE_STRING",
+        "jsonName": "subject"
+      }]
+    }, {
+      "name": "HelloResp",
+      "field": [{
+        "name": "text",
+        "number": 1,
+        "label": "LABEL_OPTIONAL",
+        "type": "TYPE_STRING",
+        "jsonName": "text"
+      }]
+    }],
+    "service": [{
+      "name": "HelloWorld",
+      "method": [{
+        "name": "Hello",
+        "inputType": ".com.example.helloworld.HelloReq",
+        "outputType": ".com.example.helloworld.HelloResp"
+      }, {
+        "name": "HelloAgain",
+        "inputType": ".com.example.helloworld.HelloReq",
+        "outputType": ".com.example.helloworld.HelloResp"
+      }]
+    }],
+    "options": {
+      "javaPackage": "com.example.helloworld"
+    },
+    "syntax": "proto3"
+  }]
+}

--- a/plugin/src/test/resources/status.jakarta.json
+++ b/plugin/src/test/resources/status.jakarta.json
@@ -1,0 +1,79 @@
+{
+  "fileToGenerate": ["core.proto", "status.proto"],
+  "parameter": "target=server,type=jakarta",
+  "compilerVersion": {
+    "major": 3,
+    "minor": 5,
+    "patch": 1,
+    "suffix": ""
+  },
+  "protoFile": [{
+    "name": "core.proto",
+    "package": "com.example.helloworld",
+    "messageType": [{
+      "name": "Empty"
+    }],
+    "options": {
+      "javaPackage": "com.example.helloworld"
+    },
+    "syntax": "proto3"
+  }, {
+    "name": "status.proto",
+    "package": "com.example.helloworld",
+    "dependency": ["core.proto"],
+    "messageType": [{
+      "name": "StatusResponse",
+      "field": [{
+        "name": "status",
+        "number": 1,
+        "label": "LABEL_OPTIONAL",
+        "type": "TYPE_ENUM",
+        "typeName": ".com.example.helloworld.StatusResponse.StatusType",
+        "jsonName": "status"
+      }, {
+        "name": "sha",
+        "number": 2,
+        "label": "LABEL_OPTIONAL",
+        "type": "TYPE_STRING",
+        "jsonName": "sha"
+      }, {
+        "name": "date",
+        "number": 3,
+        "label": "LABEL_OPTIONAL",
+        "type": "TYPE_STRING",
+        "jsonName": "date"
+      }, {
+        "name": "version",
+        "number": 4,
+        "label": "LABEL_OPTIONAL",
+        "type": "TYPE_STRING",
+        "jsonName": "version"
+      }],
+      "enumType": [{
+        "name": "StatusType",
+        "value": [{
+          "name": "UNKNOWN",
+          "number": 0
+        }, {
+          "name": "RUNNING",
+          "number": 1
+        }, {
+          "name": "ERROR",
+          "number": 2
+        }]
+      }]
+    }],
+    "service": [{
+      "name": "Status",
+      "method": [{
+        "name": "GetStatus",
+        "inputType": ".com.example.helloworld.Empty",
+        "outputType": ".com.example.helloworld.StatusResponse"
+      }]
+    }],
+    "options": {
+      "javaPackage": "com.example.helloworld"
+    },
+    "syntax": "proto3"
+  }]
+}

--- a/runtime/jakarta/build.gradle
+++ b/runtime/jakarta/build.gradle
@@ -1,17 +1,17 @@
 dependencies {
     implementation(project(':runtime:core'))
-    implementation("javax.servlet:javax.servlet-api:$javaxservletapiVersion")
-    implementation("javax.ws.rs:javax.ws.rs-api:$javaxwsrsapiVersion")
+    implementation("jakarta.servlet:jakarta.servlet-api:$jakartaservletapiVersion")
+    implementation("jakarta.ws.rs:jakarta.ws.rs-api:$jakartawsrsapiVersion")
     implementation("org.slf4j:slf4j-api:$slf4jVersion")
 
-    testImplementation("org.glassfish.jersey.core:jersey-common:$jerseyCommonJavaxVersion")
+    testImplementation("org.glassfish.jersey.core:jersey-common:$jerseyCommonJakartaVersion")
     testImplementation("org.mockito:mockito-junit-jupiter:$mockitoVersion")
 }
 
 publishing {
     publications {
         maven(MavenPublication) {
-            artifactId = 'flit-jaxrs-runtime'
+            artifactId = 'flit-jakarta-runtime'
             version = "1.3"
 
             from components.java

--- a/runtime/jakarta/src/main/java/com/flit/runtime/jakarta/FlitExceptionMapper.java
+++ b/runtime/jakarta/src/main/java/com/flit/runtime/jakarta/FlitExceptionMapper.java
@@ -1,0 +1,41 @@
+package com.flit.runtime.jakarta;
+
+import com.flit.runtime.FlitException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+public class FlitExceptionMapper implements ExceptionMapper<FlitException> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FlitExceptionMapper.class);
+
+  @Context
+  private HttpServletRequest request;
+
+  @Override
+  public Response toResponse(FlitException exception) {
+    LOGGER.error("Flit exception: request = {}, method = {}, code = {}, msg = {}",
+        request.getRequestURI(), request.getMethod(), exception.getErrorCode(),
+        exception.getMessage(), exception);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("code", exception.getErrorCode().getErrorCode());
+    response.put("msg", exception.getMessage());
+
+    if (exception.hasMeta()) {
+      response.put("meta", exception.getMeta());
+    }
+    return Response.status(exception.getErrorCode().getHttpStatus())
+        .type(MediaType.APPLICATION_JSON)
+        .entity(response)
+        .build();
+  }
+}

--- a/runtime/jakarta/src/main/java/com/flit/runtime/jakarta/InvalidProtobufExceptionMapper.java
+++ b/runtime/jakarta/src/main/java/com/flit/runtime/jakarta/InvalidProtobufExceptionMapper.java
@@ -1,0 +1,36 @@
+package com.flit.runtime.jakarta;
+
+import com.flit.runtime.ErrorCode;
+import com.google.protobuf.InvalidProtocolBufferException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InvalidProtobufExceptionMapper implements
+    ExceptionMapper<InvalidProtocolBufferException> {
+
+  private static final Logger LOGGER = LoggerFactory
+      .getLogger(InvalidProtobufExceptionMapper.class);
+
+  @Context private HttpServletRequest request;
+
+  @Override
+  public Response toResponse(InvalidProtocolBufferException exception) {
+    LOGGER.error("InvalidProtocolBufferException: request = {}, method = {}, msg= {}",
+        request.getRequestURI(), request.getMethod(), exception.getMessage(), exception);
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("code", ErrorCode.INVALID_ARGUMENT.getErrorCode());
+    response.put("msg", exception.getMessage());
+    return Response.status(ErrorCode.INVALID_ARGUMENT.getHttpStatus())
+        .type(MediaType.APPLICATION_JSON)
+        .entity(response)
+        .build();
+  }
+}

--- a/runtime/jakarta/src/test/java/com/flit/runtime/jakarta/FlitExceptionMapperTest.java
+++ b/runtime/jakarta/src/test/java/com/flit/runtime/jakarta/FlitExceptionMapperTest.java
@@ -1,0 +1,40 @@
+package com.flit.runtime.jakarta;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.flit.runtime.ErrorCode;
+import com.flit.runtime.FlitException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FlitExceptionMapperTest {
+
+  @Mock
+  private HttpServletRequest request;
+
+  @InjectMocks
+  private FlitExceptionMapper flitExceptionMapper = new FlitExceptionMapper();
+
+  @Test
+  void testToResponse() {
+    FlitException flit = FlitException.builder()
+        .withCause(new RuntimeException("Failed"))
+        .withErrorCode(ErrorCode.INTERNAL)
+        .withMessage("with this message")
+        .build();
+    Response response = flitExceptionMapper.toResponse(flit);
+    assertEquals(response.getStatus(), Status.INTERNAL_SERVER_ERROR.getStatusCode());
+    Map<String, Object> expectedResult = Map.of("msg", "with this message", "code", "internal");
+    assertEquals(response.getEntity(), expectedResult);
+    assertEquals(response.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
+  }
+}

--- a/runtime/jakarta/src/test/java/com/flit/runtime/jakarta/InvalidProtobufExceptionMapperTest.java
+++ b/runtime/jakarta/src/test/java/com/flit/runtime/jakarta/InvalidProtobufExceptionMapperTest.java
@@ -1,0 +1,36 @@
+package com.flit.runtime.jakarta;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InvalidProtobufExceptionMapperTest {
+
+  @Mock
+  private HttpServletRequest request;
+
+  @InjectMocks
+  private InvalidProtobufExceptionMapper mapper = new InvalidProtobufExceptionMapper();
+
+  @Test
+  void testToResponse() {
+    InvalidProtocolBufferException exception = new InvalidProtocolBufferException(
+        "something happened");
+    Response response = mapper.toResponse(exception);
+    assertEquals(response.getStatus(), 400);
+    Map<String, Object> expectedResult = Map
+        .of("msg", "something happened", "code", "invalid_argument");
+    assertEquals(response.getEntity(), expectedResult);
+    assertEquals(response.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,4 @@ include 'runtime:core'
 include 'runtime:spring'
 include 'runtime:undertow'
 include 'runtime:jaxrs'
-
+include 'runtime:jakarta'


### PR DESCRIPTION
* adds new jakarta runtime (aka a direct copy from javax version)
* dropwizard 4.0.0 release using the [see here](https://www.dropwizard.io/en/release-4.0.x/manual/upgrade-notes/upgrade-notes-4_0_x.html) and [here](https://github.com/dropwizard/dropwizard/releases/tag/v4.0.0)
* uses version `5.0.0` and `3.0.0` since that's what dropwizard uses (it's not the latest)
* add jakarta rpc generate for plugin as well

should automatically push the jar to `com.flit:flit-jakarta-runtime:1.3.0` when this is merged 👍🏻 

cc @github/data-pipelines 