### PR TITLE
add try-with-resources around json parsing in controllers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,13 @@
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'dev.poolside.gradle.semantic-version' version '0.1.5'
+    id 'dev.poolside.gradle.semantic-version' version '1.0.0'
 }
 
 allprojects {
     apply plugin: 'java-library'
     apply plugin: 'maven-publish'
+    apply plugin: 'dev.poolside.gradle.semantic-version'
 
     repositories {
         mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id 'com.gradleup.shadow' version '8.3.8'
 }
 
 dependencies {

--- a/plugin/src/main/java/com/flit/protoc/gen/server/jakarta/RpcGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/jakarta/RpcGenerator.java
@@ -78,10 +78,14 @@ public class RpcGenerator extends BaseGenerator {
         .nextControlFlow("else if (request.getContentType().startsWith($S))", "application/json")
         .addStatement("json = true")
         .addStatement("$T.Builder builder = $T.newBuilder()", inputType, inputType)
-        .addStatement("$T.parser().merge(new $T(request.getInputStream(), $T.UTF_8), builder)",
-            Types.JsonFormat,
+        // try with resources
+        .beginControlFlow("try ($T reader = new $T(request.getInputStream(), $T.UTF_8))",
+            Types.InputStreamReader,
             Types.InputStreamReader,
             Types.StandardCharsets)
+        .addStatement("$T.parser().merge(reader, builder)",
+            Types.JsonFormat)
+        .endControlFlow()
         .addStatement("data = builder.build()")
         .nextControlFlow("else")
         .addStatement("response.setStatus(415)")

--- a/plugin/src/main/java/com/flit/protoc/gen/server/jaxrs/RpcGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/jaxrs/RpcGenerator.java
@@ -78,10 +78,14 @@ public class RpcGenerator extends BaseGenerator {
         .nextControlFlow("else if (request.getContentType().startsWith($S))", "application/json")
         .addStatement("json = true")
         .addStatement("$T.Builder builder = $T.newBuilder()", inputType, inputType)
-        .addStatement("$T.parser().merge(new $T(request.getInputStream(), $T.UTF_8), builder)",
-            Types.JsonFormat,
+        // try with resources
+        .beginControlFlow("try ($T reader = new $T(request.getInputStream(), $T.UTF_8))",
+            Types.InputStreamReader,
             Types.InputStreamReader,
             Types.StandardCharsets)
+        .addStatement("$T.parser().merge(reader, builder)",
+            Types.JsonFormat)
+        .endControlFlow()
         .addStatement("data = builder.build()")
         .nextControlFlow("else")
         .addStatement("response.setStatus(415)")

--- a/plugin/src/main/java/com/flit/protoc/gen/server/spring/RpcGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/spring/RpcGenerator.java
@@ -61,10 +61,14 @@ class RpcGenerator extends BaseGenerator {
       .nextControlFlow("else if (request.getContentType().startsWith($S))", "application/json")
       .addStatement("json = true")
       .addStatement("$T.Builder builder = $T.newBuilder()", inputType, inputType)
-      .addStatement("$T.parser().merge(new $T(request.getInputStream(), $T.UTF_8), builder)",
-        Types.JsonFormat,
+      // try with resources
+      .beginControlFlow("try ($T reader = new $T(request.getInputStream(), $T.UTF_8))",
+        Types.InputStreamReader,
         Types.InputStreamReader,
         Types.StandardCharsets)
+      .addStatement("$T.parser().merge(reader, builder)",
+        Types.JsonFormat)
+      .endControlFlow()
       .addStatement("data = builder.build()")
       .nextControlFlow("else")
       .addStatement("response.setStatus(415)")

--- a/plugin/src/main/java/com/flit/protoc/gen/server/undertow/RpcGenerator.java
+++ b/plugin/src/main/java/com/flit/protoc/gen/server/undertow/RpcGenerator.java
@@ -137,7 +137,14 @@ class RpcGenerator extends BaseGenerator {
       .nextControlFlow("else if (contentType.startsWith($S))", "application/json")
       .addStatement("json = true")
       .addStatement("$T.Builder builder = $T.newBuilder()", inputType, inputType)
-      .addStatement("$T.parser().merge(new $T(exchange.getInputStream(), $T.UTF_8), builder)", JsonFormat, InputStreamReader, StandardCharsets)
+      // try with resources
+      .beginControlFlow("try ($T reader = new $T(exchange.getInputStream(), $T.UTF_8))",
+          InputStreamReader,
+          InputStreamReader,
+          StandardCharsets)
+      .addStatement("$T.parser().merge(reader, builder)",
+          JsonFormat)
+      .endControlFlow()
       .addStatement("data = builder.build()")
       .nextControlFlow("else")
       .addStatement("exchange.setStatusCode(415)")

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/HelloworldGeneratorTest.test_Generate.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/HelloworldGeneratorTest.test_Generate.approved.txt
@@ -37,7 +37,9 @@ public class RpcHelloWorldResource {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);
@@ -67,7 +69,9 @@ public class RpcHelloWorldResource {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
@@ -39,7 +39,9 @@ public class RpcHelloWorldResource {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);
@@ -69,7 +71,9 @@ public class RpcHelloWorldResource {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/StatusGeneratorTest.test_Generate.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jakarta/StatusGeneratorTest.test_Generate.approved.txt
@@ -35,7 +35,9 @@ public class RpcStatusResource {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Core.Empty.Builder builder = Core.Empty.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jaxrs/HelloworldGeneratorTest.test_Generate.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jaxrs/HelloworldGeneratorTest.test_Generate.approved.txt
@@ -37,7 +37,9 @@ public class RpcHelloWorldResource {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);
@@ -67,7 +69,9 @@ public class RpcHelloWorldResource {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jaxrs/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jaxrs/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
@@ -39,7 +39,9 @@ public class RpcHelloWorldResource {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);
@@ -69,7 +71,9 @@ public class RpcHelloWorldResource {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/jaxrs/StatusGeneratorTest.test_Generate.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/jaxrs/StatusGeneratorTest.test_Generate.approved.txt
@@ -35,7 +35,9 @@ public class RpcStatusResource {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Core.Empty.Builder builder = Core.Empty.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/spring/HelloworldGeneratorTest.test_Generate.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/spring/HelloworldGeneratorTest.test_Generate.approved.txt
@@ -33,7 +33,9 @@ public class RpcHelloWorldController {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);
@@ -60,7 +62,9 @@ public class RpcHelloWorldController {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/spring/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/spring/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
@@ -35,7 +35,9 @@ public class RpcHelloWorldController {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);
@@ -62,7 +64,9 @@ public class RpcHelloWorldController {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/spring/StatusGeneratorTest.test_Generate.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/spring/StatusGeneratorTest.test_Generate.approved.txt
@@ -31,7 +31,9 @@ public class RpcStatusController {
     } else if (request.getContentType().startsWith("application/json")) {
       json = true;
       Core.Empty.Builder builder = Core.Empty.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       response.setStatus(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/undertow/HelloworldGeneratorTest.test_Generate.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/undertow/HelloworldGeneratorTest.test_Generate.approved.txt
@@ -69,7 +69,9 @@ public class RpcHelloWorldHandler implements HttpHandler {
     } else if (contentType.startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       exchange.setStatusCode(415);
@@ -95,7 +97,9 @@ public class RpcHelloWorldHandler implements HttpHandler {
     } else if (contentType.startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       exchange.setStatusCode(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/undertow/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/undertow/HelloworldGeneratorTest.test_GenerateWithRequest.approved.txt
@@ -71,7 +71,9 @@ public class RpcHelloWorldHandler implements HttpHandler {
     } else if (contentType.startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       exchange.setStatusCode(415);
@@ -97,7 +99,9 @@ public class RpcHelloWorldHandler implements HttpHandler {
     } else if (contentType.startsWith("application/json")) {
       json = true;
       Helloworld.HelloReq.Builder builder = Helloworld.HelloReq.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       exchange.setStatusCode(415);

--- a/plugin/src/test/java/com/flit/protoc/gen/server/undertow/StatusGeneratorTest.test_Generate.approved.txt
+++ b/plugin/src/test/java/com/flit/protoc/gen/server/undertow/StatusGeneratorTest.test_Generate.approved.txt
@@ -66,7 +66,9 @@ public class RpcStatusHandler implements HttpHandler {
     } else if (contentType.startsWith("application/json")) {
       json = true;
       Core.Empty.Builder builder = Core.Empty.newBuilder();
-      JsonFormat.parser().merge(new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8), builder);
+      try (InputStreamReader reader = new InputStreamReader(exchange.getInputStream(), StandardCharsets.UTF_8)) {
+        JsonFormat.parser().merge(reader, builder);
+      }
       data = builder.build();
     } else {
       exchange.setStatusCode(415);


### PR DESCRIPTION
- add a try-with-resources around `InputStreamReader reader = new InputStreamReader(request.getInputStream(), StandardCharsets.UTF_8)` since the json parser doesn't close the reader
- bump gradle to latest
- use new shadrow plugin

cc @github/data-pipelines 
cc https://github.com/github/pipeline-monitor/security/code-scanning/827