### PR TITLE
force commons-lang3 version to 3.18.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ allprojects {
         jerseyCommonJakartaVersion = "3.1.10"
         junitJupiterVersion = "5.12.2"
         mockitoVersion = "5.18.0"
+
+        // force version for security
+        // remove when upgrading other libraries
+        commonsLang3Version = "3.18.0" // caused by approvaltestsVersion
     }
 
     java {

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
     testImplementation("com.github.javaparser:javaparser-core:$javaparserVersion")
     testImplementation("com.approvaltests:approvaltests:$approvaltestsVersion")
+    testImplementation("org.apache.commons:commons-lang3:$commonsLang3Version")
 }
 
 shadowJar {


### PR DESCRIPTION
transitive dependency on `commons-lang3:3.17.0` forcing upgrade to 3.18.0 to clear alert https://github.com/github/flit/security/dependabot/24

```
+--- com.approvaltests:approvaltests:24.22.0
|    \--- com.approvaltests:approvaltests-util:24.22.0
|         \--- org.apache.commons:commons-lang3:3.17.0
```

`com.approvaltests:approvaltests:24.22.0` is the latest version from May https://search.maven.org/artifact/com.approvaltests/approvaltests/24.22.0/jar

cc @github/data-pipelines 
cc https://github.com/github/data-pipelines/issues/3217